### PR TITLE
add vscodium for fedora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project doesn't care about versioning.
 
 ## [Unreleased]
 
+### Added
+- Add support for general Linux codium (see [GH-13]).
+
+[GH-13]: https://github.com/lunaryorn/gnome-search-providers-vscode/pull/13
+
 ## [1.4.0] – 2021-09-08
 
 ### Added

--- a/providers/de.swsnr.searchprovider.vscode.codium.ini
+++ b/providers/de.swsnr.searchprovider.vscode.codium.ini
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=codium.desktop
+BusName=de.swsnr.searchprovider.VSCode
+ObjectPath=/de/swsnr/searchprovider/vscode/codium
+Version=2

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,16 @@ const PROVIDERS: &[ProviderDefinition] = &[
             dirname: "VSCodium",
         },
     },
+    // The standard codium package on Linux from here: https://github.com/VSCodium/vscodium.
+    // Should work for most Linux distributions packaged from here.
+    ProviderDefinition {
+        label: "VSCodium",
+        desktop_id: "codium.desktop",
+        relative_obj_path: "codium",
+        config: ConfigLocation {
+            dirname: "VSCodium",
+        },
+    },
 ];
 
 /// A recent workspace of a VSCode variant.


### PR DESCRIPTION
this adds vscodium on fedora. i've tested it and it works, the previous provider definition doesn't because the desktop file is different on fedora.

Signed-off-by: Stephen Coady <scoady@redhat.com>