### PR TITLE
Add support for multi-root workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project doesn't care about versioning.
 
 ## [Unreleased]
 
+### Added
+- Add support for multi-root workspaces, a.k.a. `.code-workspace` files (see [GH-15]).
+
+[GH-15]: https://github.com/lunaryorn/gnome-search-providers-vscode/pull/15
+
 ## [1.5.0] – 2021-09-25
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,18 @@ use gnome_search_provider_common::mainloop::*;
 use gnome_search_provider_common::matching::*;
 
 #[derive(Debug, Deserialize)]
+struct WorkspaceEntry {
+    id: String,
+    #[serde(rename = "configPath")]
+    config_path: String,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum StorageOpenedPathsListEntry {
+    Workspace {
+        workspace: WorkspaceEntry,
+    },
     Folder {
         #[serde(rename = "folderUri")]
         uri: String,
@@ -41,6 +51,7 @@ impl StorageOpenedPathsListEntry {
     /// Move this entry into a workspace URL.
     fn into_workspace_url(self) -> Option<String> {
         match self {
+            Self::Workspace { workspace } => Some(workspace.config_path),
             Self::Folder { uri } => Some(uri),
             Self::Other(_) => None,
         }
@@ -381,6 +392,7 @@ mod tests {
         assert_eq!(
             storage.into_workspace_urls(),
             vec![
+                "file:///home/foo//workspace.code-workspace",
                 "file:///home/foo//mdcat",
                 "file:///home/foo//gnome-jetbrains-search-provider",
                 "file:///home/foo//gnome-shell",

--- a/src/tests/code_1_55_storage.json
+++ b/src/tests/code_1_55_storage.json
@@ -3,6 +3,12 @@
   "openedPathsList": {
     "entries": [
       {
+        "workspace": {
+          "id": "0123456789abcdef0123456789abcdef",
+          "configPath": "file:///home/foo//workspace.code-workspace"
+        }
+      },
+      {
           "folderUri": "file:///home/foo//mdcat"
       },
       {


### PR DESCRIPTION
This patch adds multi-root workspaces saved as .code-workspace files to the results list.

Note: this is my first foray into rust-land, so any comment is more than welcome.

Closes #14 