### PR TITLE
Add support for official VSCode packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project doesn't care about versioning.
 
 ## [Unreleased]
 
+### Added
+- Add support for official VSCode packages (see [GH-18]).
+
+[GH-18]: https://github.com/lunaryorn/gnome-search-providers-vscode/pull/18
+
 ## [1.6.0] – 2021-11-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supports
 - Code OSS (Arch Linux)
 - VSCodium
 - Visual Studio Code (AUR package)
+- Visual Studio Code ([Official packages](https://code.visualstudio.com/download))
 
 Under the hood this is a small systemd user service which implements the [search provider][1] DBus API and exposes recent workspaces from VSCode.
 

--- a/providers/de.swsnr.searchprovider.vscode.official.code.ini
+++ b/providers/de.swsnr.searchprovider.vscode.official.code.ini
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=code.desktop
+BusName=de.swsnr.searchprovider.VSCode
+ObjectPath=/de/swsnr/searchprovider/vscode/official/code
+Version=2

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,13 @@ const PROVIDERS: &[ProviderDefinition] = &[
             dirname: "VSCodium",
         },
     },
+    // The official install packages from https://code.visualstudio.com/download.
+    ProviderDefinition {
+        label: "Visual Studio Code (Official package)",
+        desktop_id: "code.desktop",
+        relative_obj_path: "official/code",
+        config: ConfigLocation { dirname: "Code" },
+    },
 ];
 
 /// A recent workspace of a VSCode variant.


### PR DESCRIPTION
This should add support for all the official packages, which all seem to use the `code.desktop` naming.